### PR TITLE
Podcast challenge

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,14 @@ export default defineConfig({
   use: {
     trace: 'retain-on-failure',
     testIdAttribute: "id",
+    permissions: ["clipboard-read"]
   },
 
   projects: [
     {
       name: 'chrome',
       use: { ...devices['Desktop Chrome'] },
+      
     },
   ],
 });

--- a/tests/amazon.spec.ts
+++ b/tests/amazon.spec.ts
@@ -252,4 +252,5 @@ test.describe('Adding to Cart', () => {
     });
 
 });
-
+/////
+///

--- a/tests/podcast.spec.ts
+++ b/tests/podcast.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test('Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button' , async ({ page }) => {
+
+    await page.goto('https://music.amazon.com/')
+    page.waitForLoadState('domcontentloaded')
+    // click on podcasts
+    await page.getByRole('link', { name: 'Podcasts' }).click();
+    await expect(page).toHaveURL('https://music.amazon.com/podcasts')
+
+    // click on the first podcast shown
+    await page.locator('music-vertical-item').first().click();
+    await expect(page).toHaveURL(/https:\/\/music\.amazon\.com\/podcasts\/.+/)
+
+    //click the share button
+    const shareButton = page.getByTestId('detailHeaderButton2')
+    await shareButton.click();
+
+    const linkField = await page.locator('._3QpxCCZ2ZUyhnlmpwSU7as ').inputValue()
+    await expect(linkField).toContain('https://music.amazon.com/podcasts/')
+
+    //press the copy link button
+    const copyLinkButton = page.locator('music-button').filter({ hasText: 'Copy link' }).getByRole('button')
+    await copyLinkButton.click();
+    
+    //wait for the link to be copied??
+    await page.waitForTimeout(1200);
+
+    //verify the link copied is the same as the link in the field
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+
+    // found this method @ https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/
+
+    //debugging?
+    console.log(clipboardText)
+
+    await expect(clipboardText).toEqual(linkField)
+
+
+
+});


### PR DESCRIPTION
### Challenge: Promote the Pod
### Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button


Unfortunately, I was not able to find a way to make this test pass in the 2 hour time limit. 

I felt very confident in the flow leading up to the final screen containing the "copy link" button.

I first have playwright go to the amazon music home page, 
I noticed this page renders a bit slow so I threw in a `page.waitForLoadState('domcontentloaded')`
Then I located the podcast button, clicked it and asserted we were at in the right place.

I decided I wanted to click on the first podcast item listed on the page. 
Instead of choosing a specific one with `getbylink name:`, I chose whatever maybe be the first podcast because I am assuming the page could be dynamic and list different results based on cookies, IP location, history , etc. Hopefully making this script more helpful for universal use.

After clicking the podcast, I made a general assert for the URL to start with the usual and expect something after in the path param `await expect(page).toHaveURL(/https:\/\/music\.amazon\.com\/podcasts\/.+/)`

After this, a share button is clicked
Where we are presented with a text field containing the podcast's link and also an automatic copy link button. 

This is where things got a bit tricky....

For the purpose of this test, I knew I needed to get the textcontent displayed in the field; this is the link of the podcast. 
Creating a locator didn't feel great for this one, the source code didn't offer alot of options..
What I found looked like something possibly specific to my podcast - this might have foiled my plans to keep this script useful universally, but anyways... 

```
const linkField = await page.locator('._3QpxCCZ2ZUyhnlmpwSU7as ').inputValue()
    await expect(linkField).toContain('https://music.amazon.com/podcasts/')

```
Now that I have the `linkField` defined, all I needed to do was click the copy link button and figure out a way to either read the clipboard or paste what I've copied and compared the two. 

I'll admit, my first idea was to somehow open a new page and fill the URL with my recently copied link from the button. 
I thought maybe I could use something like `await page.goto('copylinktext') expect(page).tohaveURL('linkedField')` - I'm sure my syntax is terrible 

And  I haven't actually read the text link from the action of pressing the button... So what should I do ? Is there some sort of intercepter to set up? 

AAAAAAAAAAAAAAA

That's when I turn to the internet and found this gem [How do I access the browser clipboard with Playwright?](https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/)... I'm not entirely certain how it works but I seems to be everything I need!


Unfortunately, time is almost up on the challenge..  I thought I found the answer.. but after applying this new evaluation and running my tests, it seems that when comparing the `linkedField` text to the `clipboardText` that the system was not receiving anything in the clipboard after clicking the `copy link button`. 

I added some `waitfortimeout` and some `console.log` in attempts to debug, but for now I am stumped. 

