### PR TITLE
Podcast clipboard fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-"test": "npx playwright test --project=chrome"
+"test": "npx playwright test --project=chrome",
+"debug": "npx playwright test --project=chrome --debug"
 },
   "keywords": [],
   "author": "",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,14 @@ export default defineConfig({
   use: {
     trace: 'retain-on-failure',
     testIdAttribute: "id",
+    permissions: ["clipboard-read"]
   },
 
   projects: [
     {
       name: 'chrome',
       use: { ...devices['Desktop Chrome'] },
+      
     },
   ],
 });

--- a/tests/amazon.spec.ts
+++ b/tests/amazon.spec.ts
@@ -245,12 +245,6 @@ test.describe('Adding to Cart', () => {
         await expect(proceedToCheckoutButton).toBeVisible();
         await proceedToCheckoutButton.click();
         await expect(page).toHaveURL(/signin/);
-
-
-
-
     });
 
 });
-/////
-///

--- a/tests/amazon.spec.ts
+++ b/tests/amazon.spec.ts
@@ -252,4 +252,5 @@ test.describe('Adding to Cart', () => {
     });
 
 });
-
+/////
+///

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -1,5 +1,5 @@
 
-import { Page } from "@playwright/test";
+import { Page, BrowserContext, Locator } from "@playwright/test";
 
 export async function searchForProductEnter(page: Page, searchQuery: string) {
     const searchBox = page.getByTestId("twotabsearchtextbox");
@@ -12,4 +12,18 @@ export async function searchForProductClick(page: Page, searchQuery: string) {
     await searchBox.fill(searchQuery);
     await page.getByTestId('nav-search-submit-button').click()
 
+}
+
+export async function copyWithButton(
+    page: Page,
+    context: BrowserContext,
+    copyButton: Locator,
+    
+) {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await copyButton.click();
+    const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+    return clipboardContent;
+    
+    
 }

--- a/tests/podcast.spec.ts
+++ b/tests/podcast.spec.ts
@@ -4,7 +4,6 @@ import { copyWithButton, } from './helper';
 test('Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button' , async ({ page, context }) => {
 
     await page.goto('https://music.amazon.com/')
-    page.waitForLoadState('domcontentloaded')
     // click on podcasts
     await page.getByRole('link', { name: 'Podcasts' }).click();
     await expect(page).toHaveURL('https://music.amazon.com/podcasts')
@@ -17,7 +16,7 @@ test('Choose any podcast. Verify the shareable link matches the text copied from
     const shareButton = page.getByTestId('detailHeaderButton2')
     await shareButton.click();
 
-    const linkField = await page.locator('._3QpxCCZ2ZUyhnlmpwSU7as ').inputValue()
+    const linkField = await page.getByTestId("dialog").locator("input").inputValue();
     expect(linkField).toContain('https://music.amazon.com/podcasts/')
 
     //press the copy link button
@@ -28,7 +27,4 @@ test('Choose any podcast. Verify the shareable link matches the text copied from
     
     // verify the clipboard content is the same as the link field
     expect(clipboardText).toEqual(linkField)
-
-
-
 });

--- a/tests/podcast.spec.ts
+++ b/tests/podcast.spec.ts
@@ -1,6 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, } from '@playwright/test';
+import { copyWithButton, } from './helper';
 
-test('Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button' , async ({ page }) => {
+test('Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button' , async ({ page, context }) => {
 
     await page.goto('https://music.amazon.com/')
     page.waitForLoadState('domcontentloaded')
@@ -17,24 +18,16 @@ test('Choose any podcast. Verify the shareable link matches the text copied from
     await shareButton.click();
 
     const linkField = await page.locator('._3QpxCCZ2ZUyhnlmpwSU7as ').inputValue()
-    await expect(linkField).toContain('https://music.amazon.com/podcasts/')
+    expect(linkField).toContain('https://music.amazon.com/podcasts/')
 
     //press the copy link button
-    const copyLinkButton = page.locator('music-button').filter({ hasText: 'Copy link' }).getByRole('button')
-    await copyLinkButton.click();
+    const copyButton = page.locator('music-button').filter({ hasText: 'Copy link' }).getByRole('button')
+
+    // using the helper function read the clipboard content
+    const clipboardText = await copyWithButton(page, context, copyButton)
     
-    //wait for the link to be copied??
-    await page.waitForTimeout(1200);
-
-    //verify the link copied is the same as the link in the field
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-
-    // found this method @ https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/
-
-    //debugging?
-    console.log(clipboardText)
-
-    await expect(clipboardText).toEqual(linkField)
+    // verify the clipboard content is the same as the link field
+    expect(clipboardText).toEqual(linkField)
 
 
 

--- a/tests/podcast.spec.ts
+++ b/tests/podcast.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test('Choose any podcast. Verify the shareable link matches the text copied from the Copy Link button' , async ({ page }) => {
+
+    await page.goto('https://music.amazon.com/')
+    page.waitForLoadState('domcontentloaded')
+    // click on podcasts
+    await page.getByRole('link', { name: 'Podcasts' }).click();
+    await expect(page).toHaveURL('https://music.amazon.com/podcasts')
+
+    // click on the first podcast shown
+    await page.locator('music-vertical-item').first().click();
+    await expect(page).toHaveURL(/https:\/\/music\.amazon\.com\/podcasts\/.+/)
+
+    //click the share button
+    const shareButton = page.getByTestId('detailHeaderButton2')
+    await shareButton.click();
+
+    const linkField = await page.locator('._3QpxCCZ2ZUyhnlmpwSU7as ').inputValue()
+    await expect(linkField).toContain('https://music.amazon.com/podcasts/')
+
+    //press the copy link button
+    const copyLinkButton = page.locator('music-button').filter({ hasText: 'Copy link' }).getByRole('button')
+    await copyLinkButton.click();
+    
+    //wait for the link to be copied??
+    await page.waitForTimeout(1200);
+
+    //verify the link copied is the same as the link in the field
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+
+    // found this method @ https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/
+
+    //debugging?
+    console.log(clipboardText)
+
+    await expect(clipboardText).toEqual(linkField)
+
+
+
+});


### PR DESCRIPTION
after careful examination of the resource from [Steven Boutcher](https://hashnode.com/@StevenBoutcher) [https://stevenqa.hashnode.dev/paste-text-from-your-clipboard-in-playwright-typescript](https://stevenqa.hashnode.dev/paste-text-from-your-clipboard-in-playwright-typescript). I was able to fix my inability to read the clipboard. 

With my limited understanding on Javascript, typescript and Playwright... this has encouraged me to learn more about `BrowserContext` method and `Navigator` object

Previously I was following this resource from [Butch Mayhew](https://playwrightsolutions.com/author/butch/) [https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/](https://playwrightsolutions.com/how-do-i-access-the-browser-clipboard-with-playwright/) which I still used in part of my helper function to help me read what was actually being stored in the clipboard `await page.evaluate(() => navigator.clipboard.readText());`

However I am still unsure how Butch was able to read and use the clipboard content..
After some research, I realized I needed to add a `return` statement. 
`const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
    return clipboardContent;` 